### PR TITLE
PORT設定を環境変数から取得するように対応

### DIFF
--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -32,7 +32,12 @@ func main() {
 
 	// グレースフルシャットダウンの設定
 	go func() {
-		if err := e.Start(":8080"); err != nil && err != http.ErrServerClosed {
+		// PORT環境変数を取得、なければ8080をデフォルトにする
+		port := os.Getenv("PORT")
+		if port == "" {
+			port = "8080"
+		}
+		if err := e.Start(":"+port); err != nil && err != http.ErrServerClosed {
 			e.Logger.Fatal("shutting down the server")
 		}
 	}()
@@ -45,7 +50,7 @@ func main() {
 	// サーバーをシャットダウン
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err:= e.Shutdown(ctx); err != nil {
+	if err := e.Shutdown(ctx); err != nil {
 		e.Logger.Fatal(err)
 	}
 }

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -11,6 +11,11 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+const (
+	defaultPort = "8080"
+	portEnvKey  = "PORT"
+)
+
 // ヘルスチェック用のハンドラー
 func healthCheck(c echo.Context) error {
 	// HTTPステータス200 (OK) と、文字列 "OK" を返す
@@ -33,11 +38,11 @@ func main() {
 	// グレースフルシャットダウンの設定
 	go func() {
 		// PORT環境変数を取得、なければ8080をデフォルトにする
-		port := os.Getenv("PORT")
+		port := os.Getenv(portEnvKey)
 		if port == "" {
-			port = "8080"
+			port = defaultPort
 		}
-		if err := e.Start(":"+port); err != nil && err != http.ErrServerClosed {
+		if err := e.Start(":" + port); err != nil && err != http.ErrServerClosed {
 			e.Logger.Fatal("shutting down the server")
 		}
 	}()


### PR DESCRIPTION
タイトルの通り

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * サーバーの起動時に、環境変数「PORT」からポート番号を自動取得できるようになりました。未設定の場合は8080番ポートが使用されます。

* **スタイル**
  * エラーハンドリング時のコードのフォーマットが修正されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->