### PR TITLE
feat: リロード時の401エラー対応、LOGIN後、リロード時にダッシュボード画面強制遷移対応

### DIFF
--- a/apps/api/internal/handlers/auth.go
+++ b/apps/api/internal/handlers/auth.go
@@ -21,6 +21,8 @@ import (
 // AuthHandler 認証関連のハンドラー構造体
 type AuthHandler struct{}
 
+const refreshTokenRotationThreshold = 24 * time.Hour
+
 // NewAuthHandler 新しいAuthHandlerインスタンスを作成
 func NewAuthHandler() *AuthHandler {
 	return &AuthHandler{}
@@ -407,7 +409,7 @@ func (h *AuthHandler) RefreshToken(c echo.Context) error {
 	// 残存期間が短い場合のみrefresh_tokenをローテーション（例: 24時間未満）
 	shouldRotate := false
 	if existingUser.RefreshTokenExpiresAt != nil {
-		if time.Until(*existingUser.RefreshTokenExpiresAt) < 24*time.Hour {
+		if time.Until(*existingUser.RefreshTokenExpiresAt) < refreshTokenRotationThreshold {
 			shouldRotate = true
 		}
 	}
@@ -431,7 +433,7 @@ func (h *AuthHandler) RefreshToken(c echo.Context) error {
 			Save(ctx)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
-				Message: "Failed to update refresh token",
+				Message: "リフレッシュトークンの更新に失敗しました",
 				Code:    "UPDATE_ERROR",
 			})
 		}

--- a/apps/api/internal/handlers/auth.go
+++ b/apps/api/internal/handlers/auth.go
@@ -270,8 +270,8 @@ func (h *AuthHandler) Logout(c echo.Context) error {
 		Name:     "refresh_token",
 		Value:    "",
 		Path:     "/",
-		Domain:   "",           // 空文字でcurrent hostに設定
-		MaxAge:   -1,           // 即座に削除
+		Domain:   "", // 空文字でcurrent hostに設定
+		MaxAge:   -1, // 即座に削除
 		HttpOnly: true,
 		Secure:   util.IsProduction(),
 		SameSite: http.SameSiteLaxMode, // 開発環境でのクロスサイト許可
@@ -404,42 +404,51 @@ func (h *AuthHandler) RefreshToken(c echo.Context) error {
 		})
 	}
 
-	// 新しいリフレッシュトークンを生成（トークンローテーション）
-	newRefreshToken, err := auth.GenerateRefreshToken()
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
-			Message: "リフレッシュトークンの生成中にエラーが発生しました",
-			Code:    "REFRESH_TOKEN_ERROR",
-		})
+	// 残存期間が短い場合のみrefresh_tokenをローテーション（例: 24時間未満）
+	shouldRotate := false
+	if existingUser.RefreshTokenExpiresAt != nil {
+		if time.Until(*existingUser.RefreshTokenExpiresAt) < 24*time.Hour {
+			shouldRotate = true
+		}
 	}
 
-	// データベースのリフレッシュトークンを更新
-	// 新しいリフレッシュトークンをハッシュ化
-	newHashedRefreshToken := auth.HashRefreshToken(newRefreshToken)
-	refreshTokenExpiry := auth.GetRefreshTokenExpiry()
-	_, err = client.User.UpdateOne(existingUser).
-		SetRefreshTokenHash(newHashedRefreshToken).
-		SetRefreshTokenExpiresAt(refreshTokenExpiry).
-		Save(ctx)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
-			Message: "Failed to update refresh token",
-			Code:    "UPDATE_ERROR",
-		})
-	}
+	if shouldRotate {
+		// 新しいリフレッシュトークンを生成（トークンローテーション）
+		newRefreshToken, err := auth.GenerateRefreshToken()
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+				Message: "リフレッシュトークンの生成中にエラーが発生しました",
+				Code:    "REFRESH_TOKEN_ERROR",
+			})
+		}
 
-	// 新しいリフレッシュトークンをhttpOnly Cookieに設定(平文を使用)
-	newCookie := &http.Cookie{
-		Name:     "refresh_token",
-		Value:    newRefreshToken,
-		Path:     "/",
-		Domain:   "",                   // 空文字でcurrent hostに設定
-		MaxAge:   7 * 24 * 60 * 60,     // 7日間（秒単位）
-		HttpOnly: true,                 // XSS攻撃を防ぐ
-		Secure:   util.IsProduction(),  // 本番環境のみHTTPS必須
-		SameSite: http.SameSiteLaxMode, // 開発環境でのクロスサイト許可
+		// データベースのリフレッシュトークンを更新
+		newHashedRefreshToken := auth.HashRefreshToken(newRefreshToken)
+		refreshTokenExpiry := auth.GetRefreshTokenExpiry()
+		_, err = client.User.UpdateOne(existingUser).
+			SetRefreshTokenHash(newHashedRefreshToken).
+			SetRefreshTokenExpiresAt(refreshTokenExpiry).
+			Save(ctx)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+				Message: "Failed to update refresh token",
+				Code:    "UPDATE_ERROR",
+			})
+		}
+
+		// 新しいリフレッシュトークンをhttpOnly Cookieに設定(平文を使用)
+		newCookie := &http.Cookie{
+			Name:     "refresh_token",
+			Value:    newRefreshToken,
+			Path:     "/",
+			Domain:   "",                   // 空文字でcurrent hostに設定
+			MaxAge:   7 * 24 * 60 * 60,     // 7日間（秒単位）
+			HttpOnly: true,                 // XSS攻撃を防ぐ
+			Secure:   util.IsProduction(),  // 本番環境のみHTTPS必須
+			SameSite: http.SameSiteLaxMode, // 開発環境でのクロスサイト許可
+		}
+		c.SetCookie(newCookie)
 	}
-	c.SetCookie(newCookie)
 
 	// レスポンス作成（access_tokenのみ、refresh_tokenはCookieに保存）
 	response := models.RefreshTokenResponse{

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -17,10 +17,11 @@ export default function ChatPage() {
 
   // 認証初期化完了後、未ログインならログインへ
 
-  // 未ログインならログインへ
+  // 初期化完了後、未ログインならログインへ（元URLを保持）
   useEffect(() => {
     if (isInitialized && !user) {
-      router.replace('/login');
+      const redirectTo = encodeURIComponent('/chat');
+      router.replace(`/login?redirect=${redirectTo}`);
     }
   }, [isInitialized, user, router]);
 

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useAuthStore } from '../stores/auth';
 import { ChatLayout, Sidebar, ChatHeader } from '../components/layout';
 // import { ChatArea } from '../components/chat';
@@ -15,18 +15,18 @@ export default function ChatPage() {
   const [rooms] = useState<ChatRoom[]>([]);
   const [currentRoomId] = useState<string | undefined>(undefined);
 
-  // 認証初期化完了後、未ログインならログインへ
+  const pathname = usePathname();
 
   // 初期化完了後、未ログインならログインへ（元URLを保持）
   useEffect(() => {
     if (isInitialized && !user) {
-      const redirectTo = encodeURIComponent('/chat');
+      const redirectTo = encodeURIComponent(pathname);
       router.replace(`/login?redirect=${redirectTo}`);
     }
-  }, [isInitialized, user, router]);
+  }, [isInitialized, user, router, pathname]);
 
-  const handleLogout = async () => {
-    await logout();
+  const handleLogout = () => {
+    logout();
     router.push('/login');
   };
 

--- a/apps/web/app/components/LoginForm.tsx
+++ b/apps/web/app/components/LoginForm.tsx
@@ -10,6 +10,7 @@ import { Input } from '@repo/ui/input';
 import { FormCard, FormHeader, FormContainer, FormFields, FormFooter } from '@repo/ui/form-card';
 import { useAuthStore } from '../stores/auth';
 import { loginSchema, type LoginFormData } from '../lib/validations';
+import { DEFAULT_LOGIN_REDIRECT } from '../constants/constants';
 
 export const LoginForm: React.FC = () => {
   const router = useRouter();
@@ -35,7 +36,7 @@ export const LoginForm: React.FC = () => {
     const ok = await login(data);
     if (ok) {
       const redirect = searchParams.get('redirect');
-      const nextPath = redirect && redirect.startsWith('/') ? redirect : '/dashboard';
+      const nextPath = redirect && redirect.startsWith('/') ? redirect : DEFAULT_LOGIN_REDIRECT;
       router.push(nextPath);
     }
   };

--- a/apps/web/app/components/LoginForm.tsx
+++ b/apps/web/app/components/LoginForm.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@repo/ui/button';
 import { Input } from '@repo/ui/input';
 import { FormCard, FormHeader, FormContainer, FormFields, FormFooter } from '@repo/ui/form-card';
@@ -13,6 +13,7 @@ import { loginSchema, type LoginFormData } from '../lib/validations';
 
 export const LoginForm: React.FC = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { login, isLoading, error, clearError } = useAuthStore();
 
   // 画面遷移後の古いエラーを初期化
@@ -33,7 +34,9 @@ export const LoginForm: React.FC = () => {
     clearError();
     const ok = await login(data);
     if (ok) {
-      router.push('/dashboard');
+      const redirect = searchParams.get('redirect');
+      const nextPath = redirect && redirect.startsWith('/') ? redirect : '/dashboard';
+      router.push(nextPath);
     }
   };
 

--- a/apps/web/app/components/RegisterForm.tsx
+++ b/apps/web/app/components/RegisterForm.tsx
@@ -10,7 +10,7 @@ import { Input } from '@repo/ui/input';
 import { FormCard, FormHeader, FormContainer, FormFields, FormFooter } from '@repo/ui/form-card';
 import { useAuthStore } from '../stores/auth';
 import { registerSchema, type RegisterFormData } from '../lib/validations';
-import { HTTP_STATUS, REDIRECT_DELAY_MS } from '../constants/constants';
+import { DEFAULT_LOGIN_REDIRECT, HTTP_STATUS, REDIRECT_DELAY_MS } from '../constants/constants';
 
 export const RegisterForm: React.FC = () => {
   const router = useRouter();
@@ -37,7 +37,7 @@ export const RegisterForm: React.FC = () => {
       const result = await registerUser(data);
       if (result.ok) {
         const redirect = searchParams.get('redirect');
-        const nextPath = redirect && redirect.startsWith('/') ? redirect : '/dashboard';
+        const nextPath = redirect && redirect.startsWith('/') ? redirect : DEFAULT_LOGIN_REDIRECT;
         router.push(nextPath);
         return;
       }

--- a/apps/web/app/components/RegisterForm.tsx
+++ b/apps/web/app/components/RegisterForm.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@repo/ui/button';
 import { Input } from '@repo/ui/input';
 import { FormCard, FormHeader, FormContainer, FormFields, FormFooter } from '@repo/ui/form-card';
@@ -14,6 +14,7 @@ import { HTTP_STATUS, REDIRECT_DELAY_MS } from '../constants/constants';
 
 export const RegisterForm: React.FC = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { register: registerUser, isLoading, error, clearError } = useAuthStore();
 
   // 画面遷移後の古いエラーを初期化
@@ -35,7 +36,9 @@ export const RegisterForm: React.FC = () => {
       clearError();
       const result = await registerUser(data);
       if (result.ok) {
-        router.push('/dashboard');
+        const redirect = searchParams.get('redirect');
+        const nextPath = redirect && redirect.startsWith('/') ? redirect : '/dashboard';
+        router.push(nextPath);
         return;
       }
       if (!result.ok && result.status === HTTP_STATUS.HTTP_STATUS_CONFLICT) {

--- a/apps/web/app/constants/constants.ts
+++ b/apps/web/app/constants/constants.ts
@@ -3,3 +3,7 @@ export const HTTP_STATUS = {
 } as const;
 
 export const REDIRECT_DELAY_MS = 3000;
+
+export const DEFAULT_LOGIN_REDIRECT = '/dashboard';
+export const LOGIN_PAGE_PATH = '/login';
+export const REGISTER_PAGE_PATH = '/register';

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -7,25 +7,26 @@ import { Button } from '@repo/ui/button';
 
 export default function DashboardPage() {
   const router = useRouter();
-  const { user, isLoading, logout, loadCurrentUser } = useAuthStore();
+  const { user, isLoading, isInitialized, logout, loadCurrentUser } = useAuthStore();
   const didLoadRef = useRef(false);
 
   // 初回マウント時にユーザー取得（React StrictModeの二重実行を防止）
   useEffect(() => {
     if (didLoadRef.current) return;
+    if (!isInitialized) return; // 初期化が完了してからユーザー取得を試みる
     didLoadRef.current = true;
     if (!user) {
       loadCurrentUser().catch(() => { });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isInitialized, user, loadCurrentUser]);
 
-  // 未ログインならログインページへ遷移
+  // 初期化完了後、未ログインならログインページへ（元URLを保持）
   useEffect(() => {
-    if (!isLoading && !user) {
-      router.replace('/login');
+    if (isInitialized && !isLoading && !user) {
+      const redirectTo = encodeURIComponent('/dashboard');
+      router.replace(`/login?redirect=${redirectTo}`);
     }
-  }, [isLoading, user, router]);
+  }, [isInitialized, isLoading, user, router]);
 
   const handleLogout = () => {
     logout();

--- a/apps/web/app/dm/[roomId]/page.tsx
+++ b/apps/web/app/dm/[roomId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuthStore } from '../../stores/auth';
 import { useChatStore } from '../../stores/chat';
@@ -16,6 +16,8 @@ export default function DMPage() {
   const { user, isLoading: authLoading, isInitialized, initializeAuth } = useAuthStore();
   const { rooms, currentRoomId, setCurrentRoom, loadRooms, updateRoom, isLoading } = useChatStore();
   const fetchedRef = useRef<string | null>(null);
+
+  const pathname = usePathname();
 
   // 認証初期化(1度だけ)
   useEffect(() => {
@@ -41,10 +43,10 @@ export default function DMPage() {
   // 初期化完了後も未ログインならログインへ（元URLを保持）
   useEffect(() => {
     if (isInitialized && !authLoading && !user) {
-      const redirectTo = encodeURIComponent(`/dm/${roomId}`);
+      const redirectTo = encodeURIComponent(pathname);
       router.replace(`/login?redirect=${redirectTo}`);
     }
-  }, [isInitialized, authLoading, user, roomId, router]);
+  }, [isInitialized, authLoading, user, roomId, router, pathname]);
 
   // 現在のルーム情報を取得
   const currentRoom = rooms.find(room => room.id === roomId);

--- a/apps/web/app/dm/[roomId]/page.tsx
+++ b/apps/web/app/dm/[roomId]/page.tsx
@@ -38,12 +38,13 @@ export default function DMPage() {
     }
   }, [roomId, currentRoomId, setCurrentRoom]);
 
-  // 未ログイン時はログイン画面へ
+  // 初期化完了後も未ログインならログインへ（元URLを保持）
   useEffect(() => {
-    if (!authLoading && !user) {
-      router.replace('/login');
+    if (isInitialized && !authLoading && !user) {
+      const redirectTo = encodeURIComponent(`/dm/${roomId}`);
+      router.replace(`/login?redirect=${redirectTo}`);
     }
-  }, [authLoading, user, router]);
+  }, [isInitialized, authLoading, user, roomId, router]);
 
   // 現在のルーム情報を取得
   const currentRoom = rooms.find(room => room.id === roomId);

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import { LoginForm } from '../components/LoginForm';
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import { RegisterForm } from '../components/RegisterForm';
 
 export default function RegisterPage() {
-  return <RegisterForm />;
+  return (
+    <Suspense fallback={null}>
+      <RegisterForm />
+    </Suspense>
+  );
 }

--- a/apps/web/app/stores/auth.ts
+++ b/apps/web/app/stores/auth.ts
@@ -12,6 +12,9 @@ import type {
 // import { isAxiosError } from 'axios';
 import type { User } from '../types/auth';
 
+// 同一タブ内でのrefresh多重実行を防止するシンプルなsingleflightロック
+let refreshPromise: Promise<void> | null = null;
+
 export const useAuthStore = create<AuthStore>()(
   devtools(
     // persist機能を削除してメモリ内のみに変更（セキュリティ向上）
@@ -125,14 +128,37 @@ export const useAuthStore = create<AuthStore>()(
 
       refreshAccessToken: async () => {
         try {
-          // Next.js Route Handler 経由でバックエンドへ
-          const response = await fetch('/api/backend/refresh', { method: 'POST', credentials: 'include' });
-          if (!response.ok) {
-            throw new Error(`Failed to refresh token: ${response.status}`);
+          // 既に実行中ならそれを待つ
+          if (refreshPromise) {
+            await refreshPromise;
+            return;
           }
-          const data = await response.json();
-          const { token: accessToken } = data as { token: string };
-          set({ accessToken });
+
+          refreshPromise = (async () => {
+            // Next.js Route Handler 経由でバックエンドへ
+            const response = await fetch('/api/backend/refresh', { method: 'POST', credentials: 'include' });
+            if (!response.ok) {
+              // 401 の場合は即ログアウトし、ログインへ誘導
+              if (response.status === 401) {
+                try {
+                  const { logout } = get();
+                  await logout();
+                } finally {
+                  if (typeof window !== 'undefined') {
+                    const currentPath = window.location.pathname || '/';
+                    const redirectParam = encodeURIComponent(currentPath);
+                    window.location.href = `/login?redirect=${redirectParam}`;
+                  }
+                }
+              }
+              throw new Error(`Failed to refresh token: ${response.status}`);
+            }
+            const data = await response.json();
+            const { token: accessToken } = data as { token: string };
+            set({ accessToken });
+          })();
+
+          await refreshPromise;
         } catch (error) {
           // リフレッシュ失敗時はログアウト状態にする（ログアウトAPIは呼ばない）
           set({
@@ -142,6 +168,8 @@ export const useAuthStore = create<AuthStore>()(
             error: null,
           });
           throw error;
+        } finally {
+          refreshPromise = null;
         }
       },
 
@@ -165,19 +193,31 @@ export const useAuthStore = create<AuthStore>()(
         return (await res.json()) as User;
       },
 
-      // 手動でのユーザー情報再取得（リトライ機能付き）
+      // 手動でのユーザー情報再取得（AuthInitがrefreshを担当する前提で、プロフィール取得のみ）
       loadCurrentUser: async () => {
-        const { setLoading, _fetchUserProfileAfterRefresh } = get();
+        const { setLoading } = get();
         try {
           setLoading(true);
-          // セッションを確立するために、まずトークンをリフレッシュする
-          const user = await _fetchUserProfileAfterRefresh();
+
+          const { accessToken } = get();
+          if (!accessToken) {
+            set({ isLoading: false, isInitialized: true });
+            throw new Error('Access token is not available');
+          }
+
+          const headers: HeadersInit = { Authorization: `Bearer ${accessToken}` };
+          const res = await fetch('/api/backend/profile', {
+            headers,
+            credentials: 'include',
+          });
+          if (!res.ok) {
+            throw new Error(`プロファイルの取得に失敗しました：${res.status}`);
+          }
+          const user = (await res.json()) as User;
           set({ user, isLoading: false, error: null, isInitialized: true });
         } catch (error) {
           console.error('Load current user failed:', error);
-          // エラー時はローディング状態を解除（ユーザーとトークンはrefreshAccessTokenでクリア済み）
           set({ isLoading: false, isInitialized: true });
-          // エラーを再スローして呼び出し元で適切に処理できるようにする
           throw error;
         }
       },
@@ -189,6 +229,17 @@ export const useAuthStore = create<AuthStore>()(
 
         // テスト環境での認証データチェック
         if (typeof window !== 'undefined') {
+          // ゲストページ（/login, /register）では自動リフレッシュを行わず初期化のみ行う
+          try {
+            const path = window.location.pathname || '';
+            const guestOnly = ['/login', '/register'];
+            if (guestOnly.some((p) => path.startsWith(p))) {
+              set({ isInitialized: true, isLoading: false, error: null });
+              return;
+            }
+          } catch {
+            // no-op
+          }
           try {
             const storedAuth = localStorage.getItem('auth-storage');
             if (storedAuth) {

--- a/apps/web/app/stores/auth.ts
+++ b/apps/web/app/stores/auth.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types/auth';
 // import { isAxiosError } from 'axios';
 import type { User } from '../types/auth';
+import { LOGIN_PAGE_PATH, REGISTER_PAGE_PATH } from '../constants/constants';
 
 // 同一タブ内でのrefresh多重実行を防止するシンプルなsingleflightロック
 let refreshPromise: Promise<void> | null = null;
@@ -232,7 +233,7 @@ export const useAuthStore = create<AuthStore>()(
           // ゲストページ（/login, /register）では自動リフレッシュを行わず初期化のみ行う
           try {
             const path = window.location.pathname || '';
-            const guestOnly = ['/login', '/register'];
+            const guestOnly = [LOGIN_PAGE_PATH, REGISTER_PAGE_PATH];
             if (guestOnly.some((p) => path.startsWith(p))) {
               set({ isInitialized: true, isLoading: false, error: null });
               return;

--- a/apps/web/app/stores/chat.ts
+++ b/apps/web/app/stores/chat.ts
@@ -59,33 +59,33 @@ export const useChatStore = create<ChatState>((set, get) => ({
   // チャットルーム管理（純粋な状態管理のみ）
   setRooms: (rooms) => set({ rooms }),
   setCurrentRoom: (roomId) => set({ currentRoomId: roomId }),
-  
-  addRoom: (room) => 
+
+  addRoom: (room) =>
     set((state) => ({
       rooms: [...state.rooms, room],
       currentRoomId: room.id,
     })),
-  
+
   upsertRoom: (room) =>
     set((state) => {
       const existingIndex = state.rooms.findIndex((r) => r.id === room.id);
       const updateRooms = existingIndex === -1
         ? [...state.rooms, room]  // 新規追加
-        : state.rooms.map((r, i) => i === existingIndex ? {...r, ...room} : r); // 既存を更新
-      
+        : state.rooms.map((r, i) => i === existingIndex ? { ...r, ...room } : r); // 既存を更新
+
       return {
         rooms: updateRooms,
         currentRoomId: room.id,   // 追加/更新したルームを現在のルームに設定
       }
     }),
-  
+
   updateRoom: (roomId, updates) =>
     set((state) => ({
-      rooms: state.rooms.map(room => 
+      rooms: state.rooms.map(room =>
         room.id === roomId ? { ...room, ...updates } : room
       ),
     })),
-  
+
   removeRoom: (roomId) =>
     set((state) => ({
       rooms: state.rooms.filter(room => room.id !== roomId),


### PR DESCRIPTION
タイトルの通りです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ログイン要求時に元のページをredirectパラメータで保持し、認証後に自動復帰（Chat、DM、Dashboard）。
  - ログイン/新規登録後、redirect指定があればそのページへ、なければデフォルト（/dashboard）へ遷移。
- 改善
  - リフレッシュトークンを期限近接時のみローテーションし、不要なDB更新やクッキー設定を回避。
  - 同一タブ内のトークン更新を単一化し同時更新を防止。初期化完了を待って未ログイン判定・リダイレクトを実行。
  - 初期化時にゲストページでは自動更新をスキップするガードを追加。
- スタイル
  - 一部コード整形とLogin/RegisterにSuspenseを追加（表示/挙動は維持）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->